### PR TITLE
Add GitHub Actions workflow to build and publish Docker image and document usage

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,0 +1,65 @@
+name: Publish Docker image
+
+on:
+  push:
+    branches:
+      - main
+    tags:
+      - "v*.*.*"
+  workflow_dispatch:
+    inputs:
+      image_name:
+        description: Docker Hub repository, for example autonomyx/agent-identity
+        required: false
+        default: autonomyx/agent-identity
+      push_latest:
+        description: Also publish the latest tag
+        required: false
+        type: boolean
+        default: true
+
+env:
+  IMAGE_NAME: ${{ github.event.inputs.image_name || 'autonomyx/agent-identity' }}
+
+jobs:
+  docker:
+    name: Build and publish
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Extract Docker metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.IMAGE_NAME }}
+          tags: |
+            type=ref,event=branch
+            type=ref,event=tag
+            type=sha,prefix=sha-
+            type=raw,value=latest,enable=${{ github.event_name != 'workflow_dispatch' || inputs.push_latest }}
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: ./Dockerfile
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/README.md
+++ b/README.md
@@ -124,6 +124,26 @@ Published images:
 - Docker Hub: `autonomyx/agent-identity:latest`
 - GHCR: `ghcr.io/didoneworld/agent-identity:latest`
 
+### Publish to Docker Hub
+
+This repository includes a GitHub Actions workflow that builds the image for `linux/amd64` and `linux/arm64`, then pushes it to Docker Hub. Configure these repository secrets before running the workflow:
+
+- `DOCKERHUB_USERNAME`: Docker Hub username with access to the target repository
+- `DOCKERHUB_TOKEN`: Docker Hub access token or password
+
+Publish options:
+
+```bash
+# Publish from GitHub Actions manually:
+# Actions > Publish Docker image > Run workflow
+
+# Publish a semantic version tag from the command line:
+git tag v0.1.0
+git push origin v0.1.0
+```
+
+The manual workflow input defaults to `autonomyx/agent-identity`, and successful runs also publish `latest` unless `push_latest` is disabled.
+
 ## Run with Docker Compose
 
 Start the app with Postgres:


### PR DESCRIPTION
### Motivation

- Provide an automated way to build multi-architecture Docker images and publish them to Docker Hub from the repository.
- Document how to run the publish workflow and what secrets are required so maintainers can publish releases.

### Description

- Add a new GitHub Actions workflow at `.github/workflows/docker-publish.yml` that uses `docker/setup-buildx-action`, `docker/metadata-action`, and `docker/build-push-action` to build for `linux/amd64` and `linux/arm64` and push to Docker Hub with tags derived from branch, tag, and commit SHA, and optionally `latest`.
- The workflow supports `workflow_dispatch` inputs `image_name` and `push_latest` and reads `DOCKERHUB_USERNAME` and `DOCKERHUB_TOKEN` from repository secrets.
- Update `README.md` with a new "Publish to Docker Hub" section that documents required secrets, example manual run instructions, and the default image name and `latest` behavior.

### Testing

- No automated tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fa09e3937c83298baa11a7dc5ac725)