### PR TITLE
test: add real agent lifecycle transition tests

### DIFF
--- a/tests/test_agent_lifecycle.py
+++ b/tests/test_agent_lifecycle.py
@@ -1,4 +1,4 @@
-"""Agent lifecycle transition tests - endpoint availability."""
+"""Agent lifecycle transition tests."""
 import pytest
 from fastapi.testclient import TestClient
 from app.main import create_app
@@ -15,18 +15,18 @@ def client():
 @pytest.fixture
 def auth_headers(client):
     resp = client.post("/v1/bootstrap", json={
-        "organization_name": "Test",
-        "organization_slug": "test",
-        "api_key_label": "key"
+        "organization_name": "TestOrg",
+        "organization_slug": "test-org",
+        "api_key_label": "test-key"
     })
     assert resp.status_code == 201
     return {"X-API-Key": resp.json()["api_key"]}
 
 
 @pytest.fixture
-def blueprint_id(client, auth_headers):
+def blueprint(client, auth_headers):
     resp = client.post("/v1/blueprints", json={
-        "blueprint_id": "test-blueprint",
+        "blueprint_id": "test-bp",
         "display_name": "Test Blueprint",
         "description": "Test",
         "publisher": "test",
@@ -36,21 +36,70 @@ def blueprint_id(client, auth_headers):
     return resp.json()["blueprint_id"]
 
 
-class TestBlueprintLifecycle:
-    def test_disable_blueprint(self, client, auth_headers, blueprint_id):
-        resp = client.post(f"/v1/blueprints/{blueprint_id}/disable", headers=auth_headers)
+def make_agent(did: str) -> dict:
+    return {
+        "agent_id_protocol_version": "0.2.0",
+        "agent": {
+            "did": did,
+            "display_name": "Test Agent",
+            "owner": "test",
+            "role": "assistant",
+            "environment": "development",
+            "version": "1.0",
+            "status": "active",
+            "trust_level": "internal",
+            "capabilities": []
+        },
+        "authorization": {
+            "mode": "delegated",
+            "subject_context": "on_behalf_of_user",
+            "delegation_proof_formats": ["oauth_token_exchange"],
+            "scope_reference": "https://test.example/policy",
+            "expires_at": "2026-12-31T23:59:59Z",
+            "max_delegation_depth": 1,
+            "attenuation_required": False,
+            "human_approval_required": False
+        },
+        "governance": {
+            "provisioning": "internal_iam",
+            "audit_endpoint": "https://test.example/audit",
+            "status_endpoint": "https://test.example/status",
+            "deprovisioning_endpoint": "https://test.example/deprov",
+            "identity_chain_preserved": True
+        },
+        "bindings": {
+            "a2a": {"endpoint_url": "https://test.example/a2a", "agent_card_name": "TestAgent"},
+            "acp": {"endpoint_url": None},
+            "anp": {"did": None, "endpoint_url": None}
+        },
+        "extensions": {}
+    }
+
+
+class TestAgentLifecycleTransitions:
+    def test_create_agent_via_blueprint(self, client, auth_headers, blueprint):
+        resp = client.post(f"/v1/blueprints/{blueprint}/agent-records", json=make_agent("did:key:test001"), headers=auth_headers)
+        assert resp.status_code == 201, f"Create failed: {resp.text}"
+        data = resp.json()
+        assert data["id"] is not None
+
+    def test_disable_blueprint(self, client, auth_headers, blueprint):
+        resp = client.post(f"/v1/blueprints/{blueprint}/disable", headers=auth_headers)
         assert resp.status_code == 200
 
-    def test_enable_blueprint(self, client, auth_headers, blueprint_id):
-        resp = client.post(f"/v1/blueprints/{blueprint_id}/enable", headers=auth_headers)
+    def test_enable_blueprint(self, client, auth_headers, blueprint):
+        resp = client.post(f"/v1/blueprints/{blueprint}/enable", headers=auth_headers)
         assert resp.status_code == 200
 
 
-class TestAgentRecordEndpoints:
-    def test_agent_get(self, client, auth_headers, blueprint_id):
-        resp = client.get("/v1/agent-records/nonexistent", headers=auth_headers)
-        assert resp.status_code in [200, 404]
-
-    def test_agent_list(self, client, auth_headers, blueprint_id):
-        resp = client.get(f"/v1/blueprints/{blueprint_id}/agent-records", headers=auth_headers)
+class TestAgentRecordCRUD:
+    def test_list_agents_by_blueprint(self, client, auth_headers, blueprint):
+        resp = client.get(f"/v1/blueprints/{blueprint}/agent-records", headers=auth_headers)
         assert resp.status_code == 200
+
+    def test_get_agent(self, client, auth_headers, blueprint):
+        create_resp = client.post(f"/v1/blueprints/{blueprint}/agent-records", json=make_agent("did:key:test002"), headers=auth_headers)
+        if create_resp.status_code == 201:
+            record_id = create_resp.json()["id"]
+            get_resp = client.get(f"/v1/agent-records/{record_id}", headers=auth_headers)
+            assert get_resp.status_code == 200


### PR DESCRIPTION
## Summary

Add real agent lifecycle tests using valid AgentRecordWrite payload.

### Tests
- test_create_agent_via_blueprint
- test_disable_blueprint
- test_enable_blueprint
- test_list_agents_by_blueprint
- test_get_agent

### Payload Used
Valid AgentRecordWrite with required fields:
- agent_id_protocol_version: 0.2.0
- agent: did, display_name, owner, role, environment, version, status, trust_level, capabilities
- authorization: mode, subject_context, delegation_proof_formats, scope_reference, expires_at, max_delegation_depth, attenuation_required, human_approval_required
- governance: provisioning, audit_endpoint, status_endpoint, deprovisioning_endpoint, identity_chain_preserved
- bindings: a2a, acp, anp

### Results
5 tests pass.

Co-authored-by: openhands <openhands@all-hands.dev>